### PR TITLE
Business required

### DIFF
--- a/DeprecationTool/DeprecationTool.csproj
+++ b/DeprecationTool/DeprecationTool.csproj
@@ -221,6 +221,8 @@ xcopy "C:\Users\asa\source\repos\Testxrmtoolbox\Testxrmtoolbox\bin\Debug\Microso
       <InputAssemblies Include="$(TargetPath)" />
       <InputAssemblies Include="$(TargetDir)Lib.dll" />
       <InputAssemblies Include="$(TargetDir)FSharp.Core.dll" />
+      <InputAssemblies Include="$(TargetDir)FParsecCS.dll" />
+      <InputAssemblies Include="$(TargetDir)FParsec.dll" />
     </ItemGroup>
     <Exec Command="$(ILRepack) /parallel /out:$(TargetDir)ILMerged.$(TargetFileName) /lib:$(TargetDir) @(InputAssemblies -> '%(Identity)', ' ')" />
   </Target>

--- a/Lib/Deprecate.fs
+++ b/Lib/Deprecate.fs
@@ -9,10 +9,14 @@ open Requests
 module Deprecate =
   let createOrUpdateDescriptionStamp (description: string) (wasSearchable: bool) =
     let cleanDescription = removeDescriptionTimestamp description
-    let searchable = if wasSearchable then WAS_SEARCHABLE_YES else WAS_SEARCHABLE_NO
-    let deprecationDate = sprintf "\n(Deprecated: %A, was searchable: %s)" DateTime.Now searchable
-    cleanDescription + deprecationDate
+    let deprecationDescription = 
+      { date = DateTime.Now
+        wasSearchable = wasSearchable
+        wasRequired = false }
+      |> textFromDeprecationDescription
 
+    cleanDescription + deprecationDescription
+    
   let safeAddDeprecationPrefix (displayName: string) (prefix: string) =
     if startsWithPrefix displayName prefix 
     then displayName

--- a/Lib/Deprecate.fs
+++ b/Lib/Deprecate.fs
@@ -10,9 +10,9 @@ module Deprecate =
   let createOrUpdateDescriptionStamp (description: string) (wasSearchable: bool) (wasRequired: bool) =
     let cleanDescription = removeDescriptionTimestamp description
     let deprecationDescription = 
-      { date = DateTime.Now
+      { date          = DateTime.Now
         wasSearchable = wasSearchable
-        wasRequired = false }
+        wasRequired   = wasRequired }
       |> textFromDeprecationDescription
 
     cleanDescription + deprecationDescription

--- a/Lib/Deprecate.fs
+++ b/Lib/Deprecate.fs
@@ -87,8 +87,8 @@ module Deprecate =
     let builderWithPrefix = buildAction prefix
 
     pendingChanges attrs
-    |> Array.Parallel.map(fun x -> decideAction x.deprecationState x.metaData)
-    |> Array.Parallel.map(fun x -> builderWithPrefix x)
-    |> Array.Parallel.map(fun x -> x :> OrganizationRequest)
-    |> Array.chunkBySize(1000)
+    |> Array.Parallel.map (fun x -> decideAction x.deprecationState x.metaData)
+    |> Array.Parallel.map (builderWithPrefix)
+    |> Array.Parallel.map (fun x -> x :> OrganizationRequest)
+    |> Array.chunkBySize  1000
     |> Array.map(fun x -> executeRequests proxy x)

--- a/Lib/Functions.fs
+++ b/Lib/Functions.fs
@@ -5,27 +5,18 @@ open Microsoft.Xrm.Sdk
 open Microsoft.Xrm.Sdk.Metadata
 open System.Globalization
 open Types
+open Parser
 open System.Text.RegularExpressions
 
 module Functions = 
-  // This should be done using a parser if it needs to be extended. This is not readable at all.
-  // especially if we need to provide backwards compatibility
-  let deprecationStampPattern = 
-    @"\n?(\(Deprecated:)\s*(?<date>\d{2,}\/\d{2,}\/\d{4,}\s*\d{2,}.\d{2,}.\d{2,}),\s*(was searchable|search):\s*(?<searchable>(1|0)|(yes|no))?(\))"
+  let deprecationDescriptionRegex = 
+    @"\n?\(Deprecated.*\)$"
 
-  let parseDescriptionStamp (description: string) =
-    let dateMatch = Regex.Match(description, deprecationStampPattern).Groups.["date"].Value
-
-    match dateMatch with
-    | "" -> None
-    | s  -> Some(s)
-
-  let isDescriptionSearchable (description: string) = 
-    match Regex.Match(description, deprecationStampPattern).Groups.["searchable"].Value with
-    | "0"  -> false
-    | "no" -> false
-    | _   -> true // if no searchable vlaue is found, just return 1, implying we should reenable search
-
+  let descriptionDetails (description: string) = 
+    let firstPass = Regex.Match(description, deprecationDescriptionRegex)
+    if firstPass.Success
+    then parseDescription firstPass.Value
+    else None
 
   let textFromDeprecationDescription depdesc = 
     let searchable = if depdesc.wasSearchable then YES_IDENTIFIER else NO_IDENTIFIER
@@ -54,9 +45,8 @@ module Functions =
     attrMetaData.IsValidForAdvancedFind.Value |> not
 
   let hasDeprecationDescription (attr: AttributeMetadata) = 
-    match (parseDescriptionStamp (labelToString attr.Description)) with
-    | Some(x) -> true
-    | _ -> false
+    let rawDescription = labelToString attr.Description
+    Regex.Match(rawDescription, deprecationDescriptionRegex).Success
 
   let isDeprecated (attr: AttributeMetadata) prefix =
     (isSearchable attr) && (hasDeprecationDescription attr) && (attrStartsWithPrefix attr prefix)
@@ -65,7 +55,7 @@ module Functions =
     (attrStartsWithPrefix attr prefix)
 
   let removeDescriptionTimestamp (description: string) =
-    Regex.Replace(description, deprecationStampPattern, "");
+    Regex.Replace(description, deprecationDescriptionRegex, "");
 
   let getDeprecationState (attr: AttributeMetadata) prefix =
     match attr with
@@ -73,6 +63,16 @@ module Functions =
     | x when (isPartiallyDeprecated x prefix) -> DeprecationState.Partial
     | _ -> DeprecationState.Favored
 
+
+  let wasSearchable = function
+  | Some(x) -> x.wasSearchable
+  | _ -> true
+
+  let wasRequired = function
+  | Some(x) -> if x.wasRequired 
+               then Metadata.AttributeRequiredLevel.ApplicationRequired 
+               else Metadata.AttributeRequiredLevel.None
+  | _ -> Metadata.AttributeRequiredLevel.None
 
   // if prefix is empty, it crashes. 
   // We need to check the given attribute metadata contains info or we can get a null pointer exeception.

--- a/Lib/Functions.fs
+++ b/Lib/Functions.fs
@@ -27,6 +27,11 @@ module Functions =
     | _   -> true // if no searchable vlaue is found, just return 1, implying we should reenable search
 
 
+  let textFromDeprecationDescription depdesc = 
+    let searchable = if depdesc.wasSearchable then YES_IDENTIFIER else NO_IDENTIFIER
+    let required = if depdesc.wasRequired then YES_IDENTIFIER else NO_IDENTIFIER
+    sprintf "\n(Deprecated: %A, was searchable: %s, was required: %s)" DateTime.Now searchable required
+
   let DeprecationStateToCheckBoxLiteral = function
     | DeprecationState.Favored -> UNCHECKED
     | DeprecationState.Deprecated -> CHECKED

--- a/Lib/Lib.fsproj
+++ b/Lib/Lib.fsproj
@@ -43,8 +43,8 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Types.fs" />
-    <Compile Include="Functions.fs" />
     <Compile Include="Parser.fs" />
+    <Compile Include="Functions.fs" />
     <Compile Include="Requests.fs" />
     <Compile Include="Deprecate.fs" />
     <None Include="Script.fsx" />
@@ -58,7 +58,7 @@
       <HintPath>..\packages\FParsec.1.1.0\lib\net45\FParsecCS.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core">
-      <HintPath>..\packages\FSharp.Core.4.5.2\lib\net45\FSharp.Core.dll</HintPath>
+      <HintPath>..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.17\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/Lib/Lib.fsproj
+++ b/Lib/Lib.fsproj
@@ -44,12 +44,19 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="Functions.fs" />
+    <Compile Include="Parser.fs" />
     <Compile Include="Requests.fs" />
     <Compile Include="Deprecate.fs" />
     <None Include="Script.fsx" />
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FParsec">
+      <HintPath>..\packages\FParsec.1.1.0\lib\net45\FParsec.dll</HintPath>
+    </Reference>
+    <Reference Include="FParsecCS">
+      <HintPath>..\packages\FParsec.1.1.0\lib\net45\FParsecCS.dll</HintPath>
+    </Reference>
     <Reference Include="FSharp.Core">
       <HintPath>..\packages\FSharp.Core.4.5.2\lib\net45\FSharp.Core.dll</HintPath>
     </Reference>

--- a/Lib/Parser.fs
+++ b/Lib/Parser.fs
@@ -1,0 +1,50 @@
+﻿namespace Lib
+
+open FParsec
+open System
+
+module Parser =
+  type DeprecationDescription = {
+    date: DateTime;
+    wasSearchable: bool;
+    wasRequired: bool;
+  }
+
+  let extendedBoolean = function
+    | "yes" -> true
+    | "1"   -> true
+    | _     -> false
+
+  let decideRequired = function
+    | Some(x) -> x
+    | None    -> "yes"
+  
+
+  let private parser =
+      let str_ws s = pstringCI s .>> spaces
+      let char_ws c = pchar c .>> spaces
+      let anyCharsTill pEnd = manyCharsTill anyChar pEnd
+      let keyValue = anyCharsTill (pchar ',' <|> pchar ')')
+      let onlyValueAfter prefix = prefix >>. keyValue
+
+      let searchableChoice = str_ws "search:" <|> str_ws "was searchable:"
+      let requiredChoice   = str_ws "was required:"
+
+      let date          = onlyValueAfter <| str_ws "Deprecated:"
+      let wasSearchable = spaces >>. onlyValueAfter searchableChoice
+      let wasRequired   = opt (spaces >>. onlyValueAfter requiredChoice)
+
+      let createDeprecationDescription date search required = {
+          date          = DateTime.Parse(date)
+          wasSearchable = extendedBoolean search
+          wasRequired   = extendedBoolean (decideRequired required)
+      }
+
+      let commit = pipe3 date wasSearchable wasRequired createDeprecationDescription
+
+      opt unicodeSpaces >>. char_ws '(' >>. commit .>> (opt <| char_ws ')') .>> unicodeSpaces .>> eof
+
+  let parseDescription log =
+      match log |> run parser with
+      | Success(v,_,_)   -> v
+      | Failure(msg,_,_) -> failwith msg

--- a/Lib/Parser.fs
+++ b/Lib/Parser.fs
@@ -39,7 +39,7 @@ module Parser =
 
       opt unicodeSpaces >>. char_ws '(' >>. description .>> unicodeSpaces .>> eof
 
-  let parseDescription log =
-      match log |> run parser with
+  let parseDescription desc =
+      match desc |> run parser with
       | Success(v,_,_) -> Some(v)
       | Failure(_,_,_) -> None

--- a/Lib/Types.fs
+++ b/Lib/Types.fs
@@ -13,9 +13,9 @@ module Types =
   let INDETERMINATE = "indeterminate";
 
   [<Literal>]
-  let WAS_SEARCHABLE_YES = "yes";
+  let YES_IDENTIFIER = "yes";
   [<Literal>]
-  let WAS_SEARCHABLE_NO = "no";
+  let NO_IDENTIFIER = "no";
 
   let labelToString (label: Label) =
     label.UserLocalizedLabel.Label.ToString()
@@ -25,6 +25,12 @@ module Types =
                         | Partial = 2 // Partial deprecation means only the name has been prefixed as deprecated.
 
   type LogicalName = string
+
+  type DeprecationDescription = {
+    date: DateTime;
+    wasSearchable: bool;
+    wasRequired: bool;
+  }
 
   type FieldNames = {
     logicalName: string

--- a/Lib/packages.config
+++ b/Lib/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FParsec" version="1.1.0" targetFramework="net462" />
   <package id="FSharp.Core" version="4.5.2" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.17" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />

--- a/Lib/packages.config
+++ b/Lib/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FParsec" version="1.1.0" targetFramework="net462" />
-  <package id="FSharp.Core" version="4.5.2" targetFramework="net462" />
+  <package id="FSharp.Core" version="4.3.4" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.17" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
semi closes #10 for now we only set field requirement to optional :)

I changed from regex to a proper parser, so it is maintainable. 
description tag now looks like this:
`(Deprecated: 29/01/2020 13.04.29, was searchable: no, was required: no)`