### PR TITLE
Currency field

### DIFF
--- a/DeprecationTool/DeprecateControl.cs
+++ b/DeprecationTool/DeprecateControl.cs
@@ -77,7 +77,7 @@ namespace DeprecationTool
                     new Uri("https://github.com/delegateas/DeprecationTool/blob/master/README.md"));
 
                 pluginSettings.FieldPrefix = "";
-                pluginSettings.DeprecationPrefix = "zz_";
+                pluginSettings.DeprecationPrefix = "ZZ_";
             }
 
         }

--- a/DeprecationTool/DeprecateControl.cs
+++ b/DeprecationTool/DeprecateControl.cs
@@ -384,7 +384,7 @@ namespace DeprecationTool
                     if (args.Error != null)
                         MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     FieldButtonsEnabled(true);
-                    MessageBox.Show("Remember to publish the entity/all after deprecations!", 
+                    MessageBox.Show("Remember to publish the entity/all after deprecations! Data inconsistency might happen.", 
                         "Notice, poublish changes!", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             });

--- a/DeprecationTool/DeprecateControl.cs
+++ b/DeprecationTool/DeprecateControl.cs
@@ -165,7 +165,7 @@ namespace DeprecationTool
                     if (!(args.Result is Tuple<string, Types.EntityWithFields> result)) return;
                     if (!solutionsWithData.TryGetValue(solutionName, out var res)) return;
                     res[entityName] = result.Item2;
-                    PopulateFieldListView(result.Item2);
+                    PopulateFieldListView(res[entityName]);
                     FieldButtonsEnabled(true);
                 }
             };

--- a/DeprecationTool/DeprecateControl.cs
+++ b/DeprecationTool/DeprecateControl.cs
@@ -19,7 +19,7 @@ namespace DeprecationTool
         private FormState formState;
         private Settings pluginSettings;
         private Types.SolutionData[] solutions;
-        private IDictionary<string, Dictionary<string, Types.EntityWithFields>> solutionsWithData;
+        private Dictionary<string, Dictionary<string, Types.EntityWithFields>> solutionsWithData;
 
         public DeprecateControl()
         {
@@ -116,7 +116,7 @@ namespace DeprecationTool
                     if (args.Error != null)
                         MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
-                    if (!(args.Result is IDictionary<string, Dictionary<string, Types.EntityWithFields>> result)) return;
+                    if (!(args.Result is Dictionary<string, Dictionary<string, Types.EntityWithFields>> result)) return;
 
                     solutionsWithData = result;
                     PopulateSolutionsComboBox();
@@ -384,6 +384,8 @@ namespace DeprecationTool
                     if (args.Error != null)
                         MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     FieldButtonsEnabled(true);
+                    MessageBox.Show("Remember to publish the entity/all after deprecations!", 
+                        "Notice, poublish changes!", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             });
         }

--- a/Lib/Functions.fs
+++ b/Lib/Functions.fs
@@ -82,6 +82,7 @@ module Functions =
           MetaData.entityLName = entityLName
           locale = attr.Description.UserLocalizedLabel.LanguageCode
           attribute = attr
+          dependantMetaData = None
           deprecationState = (getDeprecationState attr prefix) 
       }
 
@@ -91,3 +92,12 @@ module Functions =
     && x.DisplayName<> null
     && x.DisplayName.UserLocalizedLabel <> null
     && x.IsValidForAdvancedFind <> null
+
+  let combineCurrencyBaseFields (x: MetaData) (acc: MetaData list) (map: Map<LogicalName, MetaData>) suffix =
+    let logicalName = x.attribute.LogicalName
+    if logicalName.EndsWith(suffix) then
+      (acc, map)
+    else
+      let baseEntityOpt = Map.tryFind (logicalName + suffix) map
+      let metaDataWithPossibleBase = {x with dependantMetaData = baseEntityOpt}
+      (metaDataWithPossibleBase :: acc, map)

--- a/Lib/Requests.fs
+++ b/Lib/Requests.fs
@@ -113,6 +113,7 @@ module Requests =
       (sol.uniqueName, entityMetadata)
     )
     |> dict
+    |> (fun x -> Dictionary(x))
 
   let retrieveSolutionNames proxy (ignore: string[]) prefix =
     let ignoreSet = ignore |> Set.ofArray

--- a/Lib/Types.fs
+++ b/Lib/Types.fs
@@ -17,6 +17,9 @@ module Types =
   [<Literal>]
   let NO_IDENTIFIER = "no";
 
+  [<Literal>]
+  let CURRENCY_BASE = "_base";
+
   let labelToString (label: Label) =
     label.UserLocalizedLabel.Label.ToString()
 
@@ -41,6 +44,7 @@ module Types =
     entityLName: LogicalName;
     locale: int;
     attribute: AttributeMetadata;
+    dependantMetaData: MetaData option;
     mutable deprecationState: DeprecationState;
   } with 
     override this.ToString() =

--- a/Lib/Types.fs
+++ b/Lib/Types.fs
@@ -48,9 +48,9 @@ module Types =
     mutable deprecationState: DeprecationState;
   } with 
     override this.ToString() =
-      this.attribute.SchemaName
+      this.attribute.LogicalName
     member this.ColumnNames() =
-      { logicalName = this.attribute.SchemaName
+      { logicalName = this.attribute.LogicalName
         displayName = labelToString this.attribute.DisplayName }
 
   type EntityWithFields = {


### PR DESCRIPTION
Closes #25 and #23 
An issue was found and fixed too.

When deprecating a field, it is necessary to publish the entity or all, such that the data is inconsistent. Otherwise fetching data from CRM behaves unexpectedly. 
This is fixed by prompting the user to publish changes on their own. Publish All might take too long, and the complexity of publishing single entities is not for this PR.